### PR TITLE
Possible fix to Flexible Unit

### DIFF
--- a/src/units/groups/mass.ts
+++ b/src/units/groups/mass.ts
@@ -14,7 +14,7 @@ mass.Editor.add(
             short: ["%0g"],
             long: {
                 sg: ["%0gram", "%0gramme"],
-                pl: ["%grams", "%0grammes"],
+                pl: ["%0grams", "%0grammes"],
             },
         },
         1,


### PR DESCRIPTION
It appears the Flexible Unit for the mass group had a missing "0" in the plural "%0grams" string.

Apologizes if this was intentional, but it was causing a crash in my Vite project, and this change seemed to fix it.